### PR TITLE
Fix cobs compiler error

### DIFF
--- a/lib/cobs/cobs.cpp
+++ b/lib/cobs/cobs.cpp
@@ -1,7 +1,7 @@
 #include "cobs.hpp"
 
-#include <cstdint>
-#include <cstdlib>
+#include <stdint.h>
+#include <stdlib.h>
 
 namespace amber::cobs {
 
@@ -31,13 +31,6 @@ bool Decoder::Decode(const uint8_t* encoded, size_t encoded_length) {
         }
     }
     return false;
-}
-
-constexpr size_t MaxEncodedLength(size_t raw_length) {
-    constexpr size_t LEADING_ZERO = 1;
-    constexpr size_t TERMINATING_ZERO = 1;
-    size_t MAX_STUFF_BYTES = (raw_length + 253) / 254;
-    return LEADING_ZERO + raw_length + MAX_STUFF_BYTES + TERMINATING_ZERO;
 }
 
 size_t Encode(const uint8_t* raw, size_t length, uint8_t* output) {

--- a/lib/cobs/cobs.hpp
+++ b/lib/cobs/cobs.hpp
@@ -5,6 +5,13 @@
 
 namespace amber::cobs {
 
+constexpr size_t MaxEncodedLength(size_t raw_length) {
+    constexpr size_t LEADING_ZERO = 1;
+    constexpr size_t TERMINATING_ZERO = 1;
+    size_t MAX_STUFF_BYTES = (raw_length + 253) / 254;
+    return LEADING_ZERO + raw_length + MAX_STUFF_BYTES + TERMINATING_ZERO;
+}
+
 class Decoder {
 public:
     Decoder(uint8_t* buffer);
@@ -17,8 +24,6 @@ private:
     uint8_t block_remaining_;
     uint8_t code_;
 };
-
-constexpr size_t MaxEncodedLength(size_t raw_length);
 
 size_t Encode(const uint8_t* raw, size_t length, uint8_t* output);
 


### PR DESCRIPTION
AVR doesn't have `<cstdint>` or `<cstdlib>`. Use the C headers instead (this doesn't harm other platforms).

`constexpr` needs to be defined in the header. I don't know how this passed before.