### PR TITLE
Fix influx crashing on capture

### DIFF
--- a/lib/rust/influx/src/lib.rs
+++ b/lib/rust/influx/src/lib.rs
@@ -165,13 +165,15 @@ impl Logger {
                         request = request.header("Authorization", format!("Token {token}"));
                     }
 
-                    request = request.body(batch.join("\n"));
+                    let body = batch.join("\n");
+                    request = request.body(body.clone());
 
-                    tracing::debug!("Making Influx request");
                     let response = request.send().await;
 
-                    match response {
-                        Ok(r) => tracing::debug!(response=?r, "Received Influx response"),
+                    match response.map(|r| r.status().as_u16()) {
+                        Ok(400) => tracing::warn!(body = body, "Invalid request"),
+                        Ok(204) => tracing::debug!("Sucessfully wrote to DB"),
+                        Ok(code) => tracing::info!(status = code, "Unknown Influx response status code"),
                         Err(e) => tracing::error!(err = ?e, "Failed to write to DB"),
                     }
 

--- a/lib/rust/influx/src/registry.rs
+++ b/lib/rust/influx/src/registry.rs
@@ -12,13 +12,13 @@ pub(crate) struct ValueRegistry {
 
 impl ValueRegistry {
     pub(crate) fn new(policy_router: PolicyRouter) -> Self {
-        let flattener = Flattener::new()
-            .set_preserve_empty_objects(true)
-            .set_preserve_empty_objects(true)
-            .set_array_formatting(ArrayFormatting::Surrounded {
-                start: "[".to_string(),
-                end: "]".to_string(),
-            });
+        let flattener =
+            Flattener::new()
+                .set_preserve_empty_objects(false)
+                .set_array_formatting(ArrayFormatting::Surrounded {
+                    start: "[".to_string(),
+                    end: "]".to_string(),
+                });
 
         Self {
             registry: HashMap::new(),


### PR DESCRIPTION
Write queries were being rejected if they contained a `vessel` field because the json Flattener was preserving empty objects which are not supported by influx

Other changes:
- Improve response error code logging